### PR TITLE
fix: update stale IOS and ANDROID innertube client versions

### DIFF
--- a/lib/info.js
+++ b/lib/info.js
@@ -487,10 +487,10 @@ const playerAPI = async (videoId, payload, options) => {
   return response;
 };
 
-const IOS_CLIENT_VERSION = "19.45.4",
+const IOS_CLIENT_VERSION = "20.10.4",
   IOS_DEVICE_MODEL = "iPhone16,2",
-  IOS_USER_AGENT_VERSION = "17_5_1",
-  IOS_OS_VERSION = "17.5.1.21F90";
+  IOS_USER_AGENT_VERSION = "18_3_2",
+  IOS_OS_VERSION = "18.3.2.22D82";
 
 const fetchIosJsonPlayer = async (videoId, options) => {
   const payload = {
@@ -553,7 +553,7 @@ const fetchIosJsonPlayer = async (videoId, options) => {
   return response;
 };
 
-const ANDROID_CLIENT_VERSION = "19.44.38",
+const ANDROID_CLIENT_VERSION = "20.10.38",
   ANDROID_OS_VERSION = "11",
   ANDROID_SDK_VERSION = "30";
 


### PR DESCRIPTION
The hardcoded client versions had been retired by YouTube, so the player endpoint answered HTTP 400 FAILED_PRECONDITION for both clients. With ANDROID_VR blocked by bot detection and WEB_EMBEDDED/TV returning their own errors, every client failed and getInfo() always threw "Failed to find any playable formats".

Bumped IOS 19.45.4 -> 20.10.4 and ANDROID 19.44.38 -> 20.10.38, with the matching OS and User-Agent strings. Isolated against the live API: the version constants are the only relevant variable, the X-Goog-Api-Format-Version header has no effect on the 400.

Verified: getInfo now returns 72 formats for aqz-KE-bpKQ, all with deciphered URLs and no leftover signatureCipher, and 8/8 sampled format URLs serve bytes (HTTP 206).